### PR TITLE
Fix send email exception when fields have the same name

### DIFF
--- a/src/Feature/FormsExtensions/code/SubmitActions/SendEmail/SendEmailBase.cs
+++ b/src/Feature/FormsExtensions/code/SubmitActions/SendEmail/SendEmailBase.cs
@@ -72,7 +72,15 @@ namespace Feature.FormsExtensions.SubmitActions.SendEmail
             customTokens.Add(Constants.CustomTokensFormKey, formFields);
             foreach (var formField in formFields)
             {
-                customTokens.Add($"form_{formField.Name}", GetSingleStringValue(formField));
+                var customTokensKeyBase = $"form_{formField.Name}";
+                var customTokensKey = customTokensKeyBase;
+                var dynamicKeyIndex = 1;
+                while (customTokens.ContainsKey(customTokensKey))
+                {
+                    customTokensKey = $"{customTokensKeyBase}_{dynamicKeyIndex}";
+                    dynamicKeyIndex++;
+                }
+                customTokens.Add(customTokensKey, GetSingleStringValue(formField));
             }
             return customTokens;
         }


### PR DESCRIPTION
Hi @bartverdonck,

Awesome extension firstly, thanks so much for developing it! 

Noticed send email action fails when there are fields with the same name so made some changes. Feel free to suggest any changes.

The change also enables fields with same names to continue work with tokens by using for example $form_firstName_1$, last digit can increase based on as many same fields as it has.

Thanks,
Ke