### PR TITLE
#51: Fix for when Tracker.Current might not yet be initialized on the…

### DIFF
--- a/src/Feature/FormsExtensions/code/SubmitActions/SendEmail/CurrentContactContactIdentierHandler.cs
+++ b/src/Feature/FormsExtensions/code/SubmitActions/SendEmail/CurrentContactContactIdentierHandler.cs
@@ -10,12 +10,10 @@ namespace Feature.FormsExtensions.SubmitActions.SendEmail
 {
     public class CurrentContactContactIdentierHandler : IExtractSendToContactIdentierHandler
     {
-        private readonly ITracker tracker;
         private readonly ILogger logger;
 
         public CurrentContactContactIdentierHandler(ILogger logger)
         {
-            tracker = Tracker.Current;
             this.logger = logger;
         }
 
@@ -32,6 +30,12 @@ namespace Feature.FormsExtensions.SubmitActions.SendEmail
 
         private ContactIdentifier GetContactIdentifier()
         {
+            var tracker = Tracker.Current;
+            if (tracker == null)
+            {
+                logger.LogWarn("Tracker.Current is null");
+                return null;
+            }
             var contact = tracker.Contact;
             var contactIdentifier = contact?.Identifiers.FirstOrDefault(c => c.Type == ContactIdentificationLevel.Known);
             return contactIdentifier == null ? null : new ContactIdentifier(contactIdentifier.Source, contactIdentifier.Identifier, ContactIdentifierType.Known);


### PR DESCRIPTION
Occasionally I have noticed that when some CD instances start up we start getting null reference exceptions on CurrentContactContactIdentierHandler - var contact = tracker.Contact;

It looks like the current singleton method will keep a possibly null tracker that failed to initialize.