### PR TITLE
SubscribeToListAction improvements

### DIFF
--- a/src/Feature/FormsExtensions/code/App_Config/Include/Feature/FormsExtensions/Feature.FormsExtensions.DependencyInjection.config
+++ b/src/Feature/FormsExtensions/code/App_Config/Include/Feature/FormsExtensions/Feature.FormsExtensions.DependencyInjection.config
@@ -2,8 +2,19 @@
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/"  xmlns:role="http://www.sitecore.net/xmlconfig/role/">
   <sitecore>
     <services>
-      <configurator type= "Feature.FormsExtensions.FormsComponentConfigurator, Feature.FormsExtensions"/>
+      <configurator type="Feature.FormsExtensions.FormsComponentConfigurator, Feature.FormsExtensions"/>
       <register serviceType="Feature.FormsExtensions.XDb.IXDbContactFactory, Feature.FormsExtensions" implementationType="Feature.FormsExtensions.XDb.FormsExtensionsXDbContactFactory, Feature.FormsExtensions" lifetime="Singleton" />
-    </services>
+
+      <!-- 
+        Adding DI for ListManagement services as SubscribeToListAction requires it (ISubscriptionService)
+        By default this is disabled for ContentDelivery role (vanilla config Sitecore.ListManagement.Services.config)
+      -->
+      <configurator type="Sitecore.ListManagement.DependencyInjection.CustomServiceConfigurator, Sitecore.ListManagement" 
+                    role:require="ContentDelivery" />
+      <configurator type="Sitecore.ListManagement.XConnect.Web.DependencyInjection.CustomServiceConfigurator, Sitecore.ListManagement.XConnect.Web" 
+                    role:require="ContentDelivery" />
+      <configurator type="Sitecore.ListManagement.Services.DependencyInjection.CustomServiceConfigurator, Sitecore.ListManagement.Services" 
+                    role:require="ContentDelivery" />
+      </services>
   </sitecore>
 </configuration>


### PR DESCRIPTION
Found the issue with `SubscribeToListAction` on Content Delivery server, `ISubscriptionService` couldn't be resolved. I found out that this is due to the Sitecore config which has set role to Standalone and ContentManagement (`Sitecore.ListManagement.Services.config`).

Changes:
- Added null checks and logging more issues to `SubscribeToListAction`
- Added missing DI for ListManagement services as `SubscribeToListAction` requires it (`ISubscriptionService`). By default this is disabled for ContentDelivery role (vanilla config `Sitecore.ListManagement.Services.config`)
- Switch to use logger service from `Sitecore.ExperienceForms.Diagnostics` instead of `Sitecore.ExM.Framework.Diagnostics`