### PR TITLE
ShowFormPageAction should not continue with form errors

### DIFF
--- a/src/Feature/FormsExtensions/code/SubmitActions/ShowFormPage/ShowFormPageAction.cs
+++ b/src/Feature/FormsExtensions/code/SubmitActions/ShowFormPage/ShowFormPageAction.cs
@@ -24,6 +24,11 @@ namespace Feature.FormsExtensions.SubmitActions.ShowFormPage
 
         protected override bool Execute(ShowFormPageData data, FormSubmitContext formSubmitContext)
         {
+            if (formSubmitContext.HasErrors)
+            {
+                // Something else has failed we should not continue
+                return false;
+            }
             if (data.FormPageId == null || data.FormPageId == Guid.Empty)
             {
                 logger.LogWarn("Empty FormPageId");


### PR DESCRIPTION
The save action shouldn't continue to the next page if something in the process
has caused an error before it.

For example if a previous submit action fails the user might want to
try and submit the form again. We wouldn't want them to assume
everything is working.

I branched off 9.0 because that's the only one I can test but I think it should be merged into all versions